### PR TITLE
Extract users to separate model. Allow to pass user id type so it can…

### DIFF
--- a/src/BioEngine.Extra.Twitter/TwitterContentPublisher.cs
+++ b/src/BioEngine.Extra.Twitter/TwitterContentPublisher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BioEngine.Core.Abstractions;
 using BioEngine.Core.DB;
 using BioEngine.Core.Entities;
 using BioEngine.Core.Social;
@@ -18,15 +19,14 @@ namespace BioEngine.Extra.Twitter
         private readonly LinkGenerator _linkGenerator;
 
         public TwitterContentPublisher(TwitterService twitterService, BioContext dbContext,
-            BioEntitiesManager entitiesManager,
             ILogger<TwitterContentPublisher> logger, LinkGenerator linkGenerator) :
-            base(dbContext, logger, entitiesManager)
+            base(dbContext, logger)
         {
             _twitterService = twitterService;
             _linkGenerator = linkGenerator;
         }
 
-        protected override Task<TwitterPublishRecord> DoPublishAsync(TwitterPublishRecord record, ContentItem entity,
+        protected override Task<TwitterPublishRecord> DoPublishAsync(TwitterPublishRecord record, IContentItem entity,
             Site site,
             TwitterPublishConfig config)
         {
@@ -43,7 +43,7 @@ namespace BioEngine.Extra.Twitter
             return Task.FromResult(record);
         }
 
-        private string ConstructText(ContentItem content, Site site, IEnumerable<string> configTags)
+        private string ConstructText(IContentItem content, Site site, IEnumerable<string> configTags)
         {
             var url = _linkGenerator.GeneratePublicUrl(content, site);
             var text = $"{content.Title} {url}";

--- a/src/BioEngine.Extra.Twitter/TwitterModule.cs
+++ b/src/BioEngine.Extra.Twitter/TwitterModule.cs
@@ -1,11 +1,14 @@
+using BioEngine.Core.DB;
 using BioEngine.Core.Entities;
 using BioEngine.Core.Modules;
 using BioEngine.Core.Properties;
 using BioEngine.Core.Social;
 using BioEngine.Extra.Twitter.Service;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace BioEngine.Extra.Twitter
 {
@@ -19,6 +22,13 @@ namespace BioEngine.Extra.Twitter
             services.AddScoped<TwitterContentPublisher>();
 
             PropertiesProvider.RegisterBioEngineProperties<TwitterSitePropertiesSet, Site>("twittersite");
+        }
+    }
+    
+    public class TwitterBioContextConfigurator: IBioContextModelConfigurator{
+        public void Configure(ModelBuilder modelBuilder, ILogger<BioContext> logger)
+        {
+            modelBuilder.RegisterEntity<TwitterPublishRecord>();
         }
     }
 }


### PR DESCRIPTION
… be defined on application level, not hardcoded as string. Separate content items. Don't use single table for them.